### PR TITLE
feat: add nop to metrics

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -3,7 +3,7 @@ const metrics = require("@operate-first/probot-metrics");
 const counter = metrics.useCounter({
   name: 'num_of_actions_total',
   help: 'Total number of actions received',
-  labelNames: ['repository', 'result', 'action'],
+  labelNames: ['repository', 'result', 'action', 'nop'],
 });
 
 const meteredPlugin = async (plugin, fn) => {
@@ -12,6 +12,7 @@ const meteredPlugin = async (plugin, fn) => {
     counter
       .labels({
         repository: plugin.repo.repo,
+        nop: plugin.nop,
         result: "success",
         action: plugin.constructor.name
       })
@@ -23,6 +24,7 @@ const meteredPlugin = async (plugin, fn) => {
       .labels({
         repository: plugin.repo.repo,
         result: "error",
+        nop: plugin.nop,
         action: plugin.constructor.name
       })
       .inc();


### PR DESCRIPTION
This will let us tell PR checks apart from real operations, so our SLO can ignore PR issues. Have tested this locally