### PR TITLE
feat: Support is_alphanumeric on autolinks

### DIFF
--- a/lib/plugins/autolinks.js
+++ b/lib/plugins/autolinks.js
@@ -13,11 +13,20 @@ module.exports = class Autolinks extends Diffable {
   }
 
   comparator (existing, attr) {
-    return existing.key_prefix === attr.key_prefix && existing.url_template === attr.url_template
+    return existing.key_prefix === attr.key_prefix &&
+      existing.url_template === attr.url_template
   }
 
   changed (existing, attr) {
-    return existing.key_prefix === attr.key_prefix && existing.url_template !== attr.url_template
+    // is_alphanumeric was added mid-2023. In order to continue to support settings yamls which dont specify this
+    // attribute, consider an unset is_alphanumeric as `true` (since that is the default value in the API)
+    // https://docs.github.com/en/rest/repos/autolinks?apiVersion=2022-11-28#create-an-autolink-reference-for-a-repository
+    const alphanumericMatches = attr.is_alphanumeric === undefined
+      ? existing.is_alphanumeric
+      : attr.is_alphanumeric === existing.is_alphanumeric
+    return existing.key_prefix === attr.key_prefix &&
+      existing.url_template !== attr.url_template &&
+      !alphanumericMatches
   }
 
   async update (existing, attr) {
@@ -25,11 +34,12 @@ module.exports = class Autolinks extends Diffable {
     return this.add(attr)
   }
 
-  async add ({ key_prefix, url_template }) {
+  async add ({ key_prefix, url_template, is_alphanumeric = true }) {
     const attrs = {
       ...this.repo,
       key_prefix,
-      url_template
+      url_template,
+      is_alphanumeric
     }
 
     if (this.nop) {

--- a/lib/plugins/autolinks.js
+++ b/lib/plugins/autolinks.js
@@ -13,8 +13,7 @@ module.exports = class Autolinks extends Diffable {
   }
 
   comparator (existing, attr) {
-    return existing.key_prefix === attr.key_prefix &&
-      existing.url_template === attr.url_template
+    return existing.key_prefix === attr.key_prefix
   }
 
   changed (existing, attr) {
@@ -24,9 +23,7 @@ module.exports = class Autolinks extends Diffable {
     const isAlphaNumericMatch = attr.is_alphanumeric === undefined
       ? existing.is_alphanumeric // === true, the default
       : attr.is_alphanumeric === existing.is_alphanumeric
-    return existing.key_prefix === attr.key_prefix &&
-      existing.url_template !== attr.url_template &&
-      !isAlphaNumericMatch
+    return existing.url_template !== attr.url_template || !isAlphaNumericMatch
   }
 
   async update (existing, attr) {

--- a/lib/plugins/autolinks.js
+++ b/lib/plugins/autolinks.js
@@ -21,12 +21,12 @@ module.exports = class Autolinks extends Diffable {
     // is_alphanumeric was added mid-2023. In order to continue to support settings yamls which dont specify this
     // attribute, consider an unset is_alphanumeric as `true` (since that is the default value in the API)
     // https://docs.github.com/en/rest/repos/autolinks?apiVersion=2022-11-28#create-an-autolink-reference-for-a-repository
-    const alphanumericMatches = attr.is_alphanumeric === undefined
-      ? existing.is_alphanumeric
+    const isAlphaNumericMatch = attr.is_alphanumeric === undefined
+      ? existing.is_alphanumeric // === true, the default
       : attr.is_alphanumeric === existing.is_alphanumeric
     return existing.key_prefix === attr.key_prefix &&
       existing.url_template !== attr.url_template &&
-      !alphanumericMatches
+      !isAlphaNumericMatch
   }
 
   async update (existing, attr) {

--- a/test/unit/lib/plugins/autolinks.test.js
+++ b/test/unit/lib/plugins/autolinks.test.js
@@ -1,0 +1,147 @@
+const Autolinks = require('../../../../lib/plugins/autolinks')
+
+describe('Autolinks', () => {
+  const repo = { owner: 'owner', repo: 'repo' }
+  let github
+
+  function configure (config) {
+    const log = { debug: jest.fn(), error: console.error }
+    const nop = false
+    const errors = []
+    return new Autolinks(nop, github, repo, config, log, errors)
+  }
+
+  beforeEach(() => {
+    github = {
+      repos: {
+        listAutolinks: jest.fn().mockResolvedValue([]),
+        createAutolink: jest.fn().mockResolvedValue(),
+        deleteAutolink: jest.fn().mockResolvedValue(),
+      }
+    }
+  })
+
+  describe('sync', () => {
+    it('syncs autolinks', () => {
+      const plugin = configure([
+        { key_prefix: 'ADD-', url_template: 'https://test/<num>' },
+        { key_prefix: 'SAME-', url_template: 'https://test/<num>' },
+        { key_prefix: 'NEW_URL-', url_template: 'https://new-url/<num>' },
+        { key_prefix: 'SAME_ALPHA-UNDEFINED-', url_template: 'https://test/<num>' },
+        { key_prefix: 'SAME_ALPHA-FALSE-', url_template: 'https://test/<num>', is_alphanumeric: false },
+        { key_prefix: 'SAME_ALPHA-TRUE-', url_template: 'https://test/<num>', is_alphanumeric: true },
+        { key_prefix: 'NEW_ALPHA-UNDEFINED-', url_template: 'https://test/<num>' },
+        { key_prefix: 'NEW_ALPHA-FALSE-', url_template: 'https://test/<num>', is_alphanumeric: false },
+        { key_prefix: 'NEW_ALPHA-TRUE-', url_template: 'https://test/<num>', is_alphanumeric: true },
+      ])
+
+      github.repos.listAutolinks.mockResolvedValueOnce({
+        data: [
+          { id: '1', key_prefix: 'SAME-', url_template: 'https://test/<num>', is_alphanumeric: true },
+          { id: '2', key_prefix: 'REMOVE-', url_template: 'https://test/<num>', is_alphanumeric: true },
+          { id: '3', key_prefix: 'NEW_URL-', url_template: 'https://current-url/<num>', is_alphanumeric: true },
+          { id: '4', key_prefix: 'SAME_ALPHA-UNDEFINED-', url_template: 'https://test/<num>', is_alphanumeric: true },
+          { id: '5', key_prefix: 'SAME_ALPHA-FALSE-', url_template: 'https://test/<num>', is_alphanumeric: false },
+          { id: '6', key_prefix: 'SAME_ALPHA-TRUE-', url_template: 'https://test/<num>', is_alphanumeric: true },
+          { id: '7', key_prefix: 'NEW_ALPHA-UNDEFINED-', url_template: 'https://test/<num>', is_alphanumeric: false },
+          { id: '8', key_prefix: 'NEW_ALPHA-FALSE-', url_template: 'https://test/<num>', is_alphanumeric: true },
+          { id: '9', key_prefix: 'NEW_ALPHA-TRUE-', url_template: 'https://test/<num>', is_alphanumeric: false },
+        ]
+      })
+
+      return plugin.sync().then(() => {
+        expect(github.repos.createAutolink).toHaveBeenCalledWith({
+          key_prefix: 'ADD-',
+          url_template: 'https://test/<num>',
+          is_alphanumeric: true,
+           ...repo
+        })
+
+        expect(github.repos.deleteAutolink).toHaveBeenCalledWith({
+          autolink_id: '2',
+           ...repo
+        })
+
+        expect(github.repos.deleteAutolink).toHaveBeenCalledWith({
+          autolink_id: '3',
+           ...repo
+        })
+        expect(github.repos.createAutolink).toHaveBeenCalledWith({
+          key_prefix: 'NEW_URL-',
+          url_template: 'https://new-url/<num>',
+          is_alphanumeric: true,
+           ...repo
+        })
+
+        expect(github.repos.deleteAutolink).not.toHaveBeenCalledWith({
+          autolink_id: '4',
+           ...repo
+        })
+        expect(github.repos.createAutolink).not.toHaveBeenCalledWith({
+          key_prefix: 'SAME_ALPHA-UNDEFINED-',
+          url_template: 'https://test/<num>',
+          is_alphanumeric: true,
+           ...repo
+        })
+
+        expect(github.repos.deleteAutolink).not.toHaveBeenCalledWith({
+          autolink_id: '5',
+           ...repo
+        })
+        expect(github.repos.createAutolink).not.toHaveBeenCalledWith({
+          key_prefix: 'SAME_ALPHA-FALSE-',
+          url_template: 'https://test/<num>',
+          is_alphanumeric: false,
+           ...repo
+        })
+
+        expect(github.repos.deleteAutolink).not.toHaveBeenCalledWith({
+          autolink_id: '6',
+           ...repo
+        })
+        expect(github.repos.createAutolink).not.toHaveBeenCalledWith({
+          key_prefix: 'SAME_ALPHA-TRUE-',
+          url_template: 'https://test/<num>',
+          is_alphanumeric: true,
+           ...repo
+        })
+
+        expect(github.repos.deleteAutolink).toHaveBeenCalledWith({
+          autolink_id: '7',
+           ...repo
+        })
+        expect(github.repos.createAutolink).toHaveBeenCalledWith({
+          key_prefix: 'NEW_ALPHA-UNDEFINED-',
+          url_template: 'https://test/<num>',
+          is_alphanumeric: true,
+           ...repo
+        })
+
+        expect(github.repos.deleteAutolink).toHaveBeenCalledWith({
+          autolink_id: '8',
+           ...repo
+        })
+        expect(github.repos.createAutolink).toHaveBeenCalledWith({
+          key_prefix: 'NEW_ALPHA-FALSE-',
+          url_template: 'https://test/<num>',
+          is_alphanumeric: false,
+           ...repo
+        })
+
+        expect(github.repos.deleteAutolink).toHaveBeenCalledWith({
+          autolink_id: '9',
+           ...repo
+        })
+        expect(github.repos.createAutolink).toHaveBeenCalledWith({
+          key_prefix: 'NEW_ALPHA-TRUE-',
+          url_template: 'https://test/<num>',
+          is_alphanumeric: true,
+           ...repo
+        })
+
+        expect(github.repos.deleteAutolink).toHaveBeenCalledTimes(5)
+        expect(github.repos.createAutolink).toHaveBeenCalledTimes(5)
+      })
+    })
+  })
+})


### PR DESCRIPTION
Fixes https://github.com/github/safe-settings/issues/502

Supersedes https://github.com/github/safe-settings/pull/517

Also, according to the unit test https://github.com/github/safe-settings/issues/521 is now fixed