### PR TITLE
fix: prde-1918 Always update review delegation

### DIFF
--- a/lib/plugins/reviewRequestDelegation.js
+++ b/lib/plugins/reviewRequestDelegation.js
@@ -125,10 +125,10 @@ module.exports = class ReviewRequestDelegation extends ErrorStash {
       }
     })
 
-    const changes = this.mergeDeep.compareDeep(entry, comparableAttrs)
+    if (this.nop) {
+      const changes = this.mergeDeep.compareDeep(entry, comparableAttrs)
 
-    if (changes.hasChanges) {
-      if (this.nop) {
+      if (changes.hasChanges) {
         return Promise.resolve([
           new NopCommand(this.constructor.name, {
             repo: slug,
@@ -137,10 +137,10 @@ module.exports = class ReviewRequestDelegation extends ErrorStash {
         ])
       }
 
-      return this.update(slug, entry, safeAttrs)
+      return Promise.resolve()
     }
 
-    return Promise.resolve()
+    return this.update(slug, entry, safeAttrs)
   }
 
   async update (slug, existing, attrs) {


### PR DESCRIPTION
Since some properties can't be queried, the values must always be updated