### PR TITLE
fix: skip missing excluded team members

### DIFF
--- a/lib/plugins/reviewRequestDelegation.js
+++ b/lib/plugins/reviewRequestDelegation.js
@@ -186,17 +186,13 @@ module.exports = class ReviewRequestDelegation extends ErrorStash {
         .map((id, index) => id === null ? excludedTeamMembers[index] : undefined)
         .filter(Boolean)
 
-    // If we couldn't find the node_id for any user for whatever reason, we shouldn't update the delegation settings
-    // as an existing valid exclusion may be removed.
     if (unfoundUsernames.length) {
-      const error = new Error(`Could not find node_id for users: ${unfoundUsernames.join(', ')}`)
-      this.handleError(error, undefined, slug)
-      return
+      this.log.warn(`Skipping missing excludedTeamMembers for ${slug}: ${unfoundUsernames.join(', ')}`)
     }
 
     const input = {
       ...params,
-      excludedTeamMemberIds
+      excludedTeamMemberIds: excludedTeamMemberIds.filter(Boolean)
     }
 
     delete input.excludedTeamMembers

--- a/lib/plugins/reviewRequestDelegation.js
+++ b/lib/plugins/reviewRequestDelegation.js
@@ -68,7 +68,7 @@ const getAllMembers = (org, github, log) => {
       per_page: 100
     }))
       .then(members => {
-        resolve(members)
+        resolve({ members, ok: true })
         setTimeout(() => {
           allMembersPromise = undefined
         }, 1000 * 60 * 30)
@@ -76,7 +76,7 @@ const getAllMembers = (org, github, log) => {
       .catch(e => {
         log.error(e)
         allMembersPromise = undefined
-        resolve([])
+        resolve({ members: [], ok: false })
       })
   })
 
@@ -85,19 +85,23 @@ const getAllMembers = (org, github, log) => {
 
 const getMemberIdFromUsername = async (org, username, github, log) => {
   if (!memberIdMap.has(username)) {
-    const members = await getAllMembers(org, github, log)
+    const { members, ok } = await getAllMembers(org, github, log)
 
     members.forEach(member => {
       memberIdMap.set(member.login, member.node_id)
     })
+
+    if (!ok) {
+      return { id: null, lookupFailed: true }
+    }
   }
 
   if (!memberIdMap.has(username)) {
     log.warn(`Could not find member with login: ${username}`)
-    return null
+    return { id: null, lookupFailed: false }
   }
 
-  return memberIdMap.get(username)
+  return { id: memberIdMap.get(username), lookupFailed: false }
 }
 
 module.exports = class ReviewRequestDelegation extends ErrorStash {
@@ -177,10 +181,19 @@ module.exports = class ReviewRequestDelegation extends ErrorStash {
     }
 
     const excludedTeamMembers = uniq(params.excludedTeamMembers ?? [])
-    const excludedTeamMemberIds =
+    const excludedTeamMemberLookups =
       await Promise.all((excludedTeamMembers)
         .map(username => getMemberIdFromUsername(this.team.owner, username, this.github, this.log)))
 
+    const hasLookupFailures = excludedTeamMemberLookups.some(({ lookupFailed }) => lookupFailed)
+
+    if (hasLookupFailures) {
+      const error = new Error('Could not fetch org members to resolve excludedTeamMembers')
+      this.handleError(error, undefined, slug)
+      return
+    }
+
+    const excludedTeamMemberIds = excludedTeamMemberLookups.map(({ id }) => id)
     const unfoundUsernames =
       excludedTeamMemberIds
         .map((id, index) => id === null ? excludedTeamMembers[index] : undefined)

--- a/test/unit/lib/plugins/reviewRequestDelegation.test.js
+++ b/test/unit/lib/plugins/reviewRequestDelegation.test.js
@@ -1,0 +1,56 @@
+describe('ReviewRequestDelegation', () => {
+  let ReviewRequestDelegation
+  let github
+  let log
+
+  beforeEach(() => {
+    jest.resetModules()
+    jest.doMock('@operate-first/probot-metrics', () => ({
+      useCounter: () => ({ labels: () => ({ inc: jest.fn() }) })
+    }))
+    ReviewRequestDelegation = require('../../../../lib/plugins/reviewRequestDelegation')
+    log = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+    github = {
+      paginate: jest.fn().mockResolvedValue([
+        { login: 'valid-user', node_id: 'NODE_ID' }
+      ]),
+      request: {
+        endpoint: {
+          merge: jest.fn()
+        }
+      },
+      graphql: jest.fn().mockResolvedValue({})
+    }
+  })
+
+  it('skips missing excludedTeamMembers while updating', async () => {
+    const plugin = new ReviewRequestDelegation(
+      false,
+      github,
+      { owner: 'acme', slug: 'team-slug' },
+      { excludedTeamMembers: ['valid-user', 'missing-user'] },
+      log,
+      []
+    )
+
+    await plugin.sync({ id: 'TEAM_ID', enabled: true })
+
+    expect(log.warn).toHaveBeenCalledWith(
+      'Skipping missing excludedTeamMembers for team-slug: missing-user'
+    )
+
+    expect(github.graphql).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        input: expect.objectContaining({
+          id: 'TEAM_ID',
+          enabled: true,
+          excludedTeamMemberIds: ['NODE_ID']
+        })
+      }
+    )
+
+    const { input } = github.graphql.mock.calls[0][1]
+    expect(input.excludedTeamMembers).toBeUndefined()
+  })
+})

--- a/test/unit/lib/plugins/reviewRequestDelegation.test.js
+++ b/test/unit/lib/plugins/reviewRequestDelegation.test.js
@@ -53,4 +53,21 @@ describe('ReviewRequestDelegation', () => {
     const { input } = github.graphql.mock.calls[0][1]
     expect(input.excludedTeamMembers).toBeUndefined()
   })
+
+  it('does not update when member lookup fails', async () => {
+    github.paginate.mockRejectedValueOnce(new Error('boom'))
+
+    const plugin = new ReviewRequestDelegation(
+      false,
+      github,
+      { owner: 'acme', slug: 'team-slug' },
+      { excludedTeamMembers: ['valid-user'] },
+      log,
+      []
+    )
+
+    await plugin.sync({ id: 'TEAM_ID', enabled: true })
+
+    expect(github.graphql).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Summary
- skip missing `excludedTeamMembers` usernames instead of failing the update
- filter missing ids and log a warning so valid exclusions remain applied
- avoid updating delegation when the org member fetch fails
- add unit tests covering missing excluded members and lookup failures

## Evidence
- Example Datadog log: https://app.datadoghq.eu/logs?query=%22Could%20not%20find%20node_id%20for%20users%22%20service%3Asafe-settings%20env%3Asbx&from_ts=1772196432000&to_ts=1772196732000&live=false

## Testing
- npm run test:unit -- --no-watchman (fails: `test/unit/index.test.js` due to Probot dependency under Node 24)
