### PR TITLE
chore: standardize GitHub Actions runs-on expression

### DIFF
--- a/.github/workflows/advanced-codeql.yml
+++ b/.github/workflows/advanced-codeql.yml
@@ -27,7 +27,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ${{ vars.GLOBAL_RUNNER_OVERWRITE || vars.TEAM_RUNNER_LABEL || 'boxed-runner' }}
     permissions:
       # required for all workflows
       security-events: write

--- a/.github/workflows/create-pre-release.yml
+++ b/.github/workflows/create-pre-release.yml
@@ -38,7 +38,7 @@ permissions:
 jobs:
   build:
     if: ${{ github.actor != 'dependabot'}}
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.GLOBAL_RUNNER_OVERWRITE || vars.TEAM_RUNNER_LABEL || 'boxed-runner' }}
     outputs:
       release: ${{ steps.prerelease.outputs.release }}
     steps:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   build:
     if: ${{ github.actor != 'dependabot'}}
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.GLOBAL_RUNNER_OVERWRITE || vars.TEAM_RUNNER_LABEL || 'boxed-runner' }}
     outputs:
       release: ${{ steps.finalrelease.outputs.release }}
     steps:
@@ -71,7 +71,7 @@ jobs:
           sbom: false
 
   helm:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.GLOBAL_RUNNER_OVERWRITE || vars.TEAM_RUNNER_LABEL || 'boxed-runner' }}
     needs: build
     steps:
       - name: Clone repo

--- a/.github/workflows/delete-old-releases.yml
+++ b/.github/workflows/delete-old-releases.yml
@@ -12,7 +12,7 @@ on:
         
 jobs:
   delete-releases:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.GLOBAL_RUNNER_OVERWRITE || vars.TEAM_RUNNER_LABEL || 'boxed-runner' }}
     steps:
     - name: Delete releases
       run: |

--- a/.github/workflows/deploy-k8s.yml
+++ b/.github/workflows/deploy-k8s.yml
@@ -25,7 +25,7 @@ jobs:
   deploy-to-k8s:
     if: ${{ github.event.inputs.status == 'passed' }}
     name: Deploy to Kubernetes
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.GLOBAL_RUNNER_OVERWRITE || vars.TEAM_RUNNER_LABEL || 'boxed-runner' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   test:
     if: ${{ github.actor != 'dependabot[bot]'}}
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.GLOBAL_RUNNER_OVERWRITE || vars.TEAM_RUNNER_LABEL || 'boxed-runner' }}
     steps:
       - uses: actions/checkout@v6
       - name: Setup node

--- a/.github/workflows/rc-release.yml
+++ b/.github/workflows/rc-release.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   rcrelease:
     name: release
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.GLOBAL_RUNNER_OVERWRITE || vars.TEAM_RUNNER_LABEL || 'boxed-runner' }}
     # if: ${{ github.event.issue.pull_request && github.event.comment.body == '/release'}}
     if: contains(github.event.pull_request.labels.*.name, 'stage')
     outputs:
@@ -43,7 +43,7 @@ jobs:
   
   image:
     name: Build and push Docker image
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.GLOBAL_RUNNER_OVERWRITE || vars.TEAM_RUNNER_LABEL || 'boxed-runner' }}
     needs: rcrelease
     permissions:
       contents: read


### PR DESCRIPTION
## Why
This change prepares this repository for the migration from the old self-hosted GitHub Actions runners to the new ARCv2-managed self-hosted runners.

Using the standard runner variables lets Platform switch workloads over centrally while still allowing repository or team-level overrides where needed. Copilot workflows use their own runner override so they can move independently of the general build fleet.

## Summary
- standardize GitHub Actions `runs-on` entries to `${{ vars.GLOBAL_RUNNER_OVERWRITE || vars.TEAM_RUNNER_LABEL || 'boxed-runner' }}`
- use `${{ vars.COPILOT_RUNNER_OVERWRITE || 'copilot-code-review-runner' }}` for Copilot workflow files
- pin `github-actions-artifact-publishing/publish-artifact` to `290f322dceb48c7a6683c873de9a3d535689f26d`
- pin invalid `github-actions-backend/build-and-test` refs to `cc09821c2cbdfb70e79e1fc970a3d457589d55a9`

## Impact
- no application code changes
- workflow jobs continue to run on self-hosted runners, but through the ARCv2-compatible labels/overrides
- action pins are updated where required so the workflows use versions that support the ARCv2 migration